### PR TITLE
Add minimum Python version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is dedicated to automate the detection of known exploited vulnerabi
 
 ## Requirements
 
-Python 3.7 or greater is required to install KEV via `pip`.
+Python 3.9 or greater is required to install KEV via `pip`.
 
 Docker is required to run scans locally. To install docker, please follow these
 [instructions](https://docs.docker.com/get-docker/).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project is dedicated to automate the detection of known exploited vulnerabi
 
 ## Requirements
 
+Python 3.7 or greater is required to install KEV via `pip`.
+
 Docker is required to run scans locally. To install docker, please follow these
 [instructions](https://docs.docker.com/get-docker/).
 


### PR DESCRIPTION
This looks like an interesting tool, and I
wanted to try it out. After failing to
install via pip, I figured out that some of
the transitive requirements
(jsonschema, semver) require python
3.9+. I want to save the time of the next
person that tries to install this via pip.

Log when trying to install via `pip` on
python3.6:

<details>
<summary>Python 3.6 Install Log</summary>

```
[root@16cfcb563a46 /]# python3 -m pip install ostorlab
WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Collecting ostorlab
  Downloading https://files.pythonhosted.org/packages/7b/77/61cd3a5023b41b53fc8b1711d288f7501397965384664041bea1855d4f05/ostorlab-0.18.18-py3-none-any.whl (691kB)
    100% |████████████████████████████████| 696kB 2.2MB/s
Collecting rich (from ostorlab)
  Downloading https://files.pythonhosted.org/packages/32/60/81ac2e7d1e3b861ab478a72e3b20fc91c4302acd2274822e493758941829/rich-12.6.0-py3-none-any.whl (237kB)
    100% |████████████████████████████████| 245kB 501kB/s
Collecting google-cloud-logging (from ostorlab)
  Downloading https://files.pythonhosted.org/packages/26/b4/05fecd87f8280af687e98489663fc67a5faadd1cb2c0ad8e8c8820941067/google_cloud_logging-3.1.2-py2.py3-none-any.whl (188kB)
    100% |████████████████████████████████| 194kB 4.3MB/s
Collecting importlib-metadata; python_version < "3.8" (from ostorlab)
  Downloading https://files.pythonhosted.org/packages/a0/a1/b153a0a4caf7a7e3f15c2cd56c7702e2cf3d89b1b359d1f1c5e59d68f4ce/importlib_metadata-4.8.3-py3-none-any.whl
Collecting semver>=3.0.0 (from ostorlab)
  Could not find a version that satisfies the requirement semver>=3.0.0 (from ostorlab) (from versions: 0.0.1, 0.0.2, 2.0.0, 2.0.1, 2.0.2, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.4.2, 2.5.0, 2.6.0, 2.7.0, 2.7.1, 2.7.2, 2.7.3, 2.7.4, 2.7.5, 2.7.6, 2.7.7, 2.7.8, 2.7.9, 2.8.0, 2.8.1, 2.9.0, 2.9.1, 2.10.0, 2.10.1, 2.10.2, 2.11.0, 2.12.0, 2.13.0, 3.0.0.dev1, 3.0.0.dev2, 3.0.0.dev3)
No matching distribution found for semver>=3.0.0 (from ostorlab)
```

</details>

Log when trying to install/run
via pip on python3.8:

<details>
<summary>Python 3.8 Install/Run Log</summary>

```
[root@d0cd328d21b8 /]# python3.8 -m pip install ostorlab
WARNING: Running pip install with root privileges is generally not a good idea. Try `python3.8 -m pip install --user` instead.
Collecting ostorlab
# ... lots of pip faffing about...
Successfully built nats-py
ERROR: googleapis-common-protos 1.62.0 has requirement protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
ERROR: grpcio-status 1.60.0 has requirement protobuf>=4.21.6, but you'll have protobuf 3.20.1 which is incompatible.
ERROR: google-api-core 2.15.0 has requirement protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
ERROR: grpc-google-iam-v1 0.13.0 has requirement protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
ERROR: google-cloud-appengine-logging 1.4.0 has requirement protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
ERROR: google-cloud-audit-log 0.2.5 has requirement protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
ERROR: google-cloud-logging 3.9.0 has requirement protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
Installing collected packages: ruamel.yaml.clib, ruamel.yaml, protobuf, click, py-ubjson, nats-py, semver, charset-normalizer, urllib3, idna, certifi, requests, googleapis-common-protos, pyasn1, pyasn1-modules, rsa, cachetools, google-auth, grpcio, grpcio-status, google-api-core, proto-plus, grpc-google-iam-v1, google-cloud-core, google-cloud-appengine-logging, google-cloud-audit-log, google-cloud-logging, attrs, rpds-py, referencing, zipp, importlib-resources, pkgutil-resolve-name, jsonschema-specifications, jsonschema, soupsieve, beautifulsoup4, six, markdownify, importlib-metadata, greenlet, sqlalchemy, typing-extensions, MarkupSafe, Mako, alembic, packaging, docker, tenacity, mdurl, markdown-it-py, pygments, rich, ostorlab
    Running setup.py install for py-ubjson ... done
Successfully installed Mako-1.3.0 MarkupSafe-2.1.3 alembic-1.13.1 attrs-23.2.0 beautifulsoup4-4.12.2 cachetools-5.3.2 certifi-2023.11.17 charset-normalizer-3.3.2 click-8.1.7 docker-7.0.0 google-api-core-2.15.0 google-auth-2.26.2 google-cloud-appengine-logging-1.4.0 google-cloud-audit-log-0.2.5 google-cloud-core-2.4.1 google-cloud-logging-3.9.0 googleapis-common-protos-1.62.0 greenlet-3.0.3 grpc-google-iam-v1-0.13.0 grpcio-1.60.0 grpcio-status-1.60.0 idna-3.6 importlib-metadata-7.0.1 importlib-resources-6.1.1 jsonschema-4.21.0 jsonschema-specifications-2023.12.1 markdown-it-py-3.0.0 markdownify-0.11.6 mdurl-0.1.2 nats-py-2.6.0 ostorlab-0.18.18 packaging-23.2 pkgutil-resolve-name-1.3.10 proto-plus-1.23.0 protobuf-3.20.1 py-ubjson-0.16.1 pyasn1-0.5.1 pyasn1-modules-0.3.0 pygments-2.17.2 referencing-0.32.1 requests-2.31.0 rich-13.7.0 rpds-py-0.17.1 rsa-4.9 ruamel.yaml-0.18.5 ruamel.yaml.clib-0.2.8 semver-3.0.2 six-1.16.0 soupsieve-2.5 sqlalchemy-1.4.51 tenacity-8.2.3 typing-extensions-4.9.0 urllib3-2.1.0 zipp-3.17.0

[root@d0cd328d21b8 /]# ostorlab
Traceback (most recent call last):
  File "/usr/local/bin/ostorlab", line 5, in <module>
    from ostorlab import main
  File "/usr/local/lib/python3.8/site-packages/ostorlab/__init__.py", line 5, in <module>
    from ostorlab.cli.rootcli import rootcli
  File "/usr/local/lib/python3.8/site-packages/ostorlab/cli/__init__.py", line 2, in <module>
    from ostorlab.cli import scan
  File "/usr/local/lib/python3.8/site-packages/ostorlab/cli/scan/__init__.py", line 2, in <module>
    from ostorlab.cli.scan.scan import scan
  File "/usr/local/lib/python3.8/site-packages/ostorlab/cli/scan/scan.py", line 8, in <module>
    from ostorlab.runtimes import registry
  File "/usr/local/lib/python3.8/site-packages/ostorlab/runtimes/registry.py", line 4, in <module>
    from ostorlab.runtimes.local import runtime as local_runtime
  File "/usr/local/lib/python3.8/site-packages/ostorlab/runtimes/local/__init__.py", line 2, in <module>
    from .runtime import LocalRuntime
  File "/usr/local/lib/python3.8/site-packages/ostorlab/runtimes/local/runtime.py", line 31, in <module>
    from ostorlab.runtimes.local.models import models
  File "/usr/local/lib/python3.8/site-packages/ostorlab/runtimes/local/models/models.py", line 46, in <module>
    class Database:
  File "/usr/local/lib/python3.8/site-packages/ostorlab/runtimes/local/models/models.py", line 65, in Database
    exc_type: Optional[type[BaseException]],
TypeError: 'type' object is not subscriptable
```

</details>

Log when trying to install/run
via pip on python3.9:

<details>
<summary>Python 3.9 Install/Run Log</summary>

```
[root@d0cd328d21b8 /]# python3.9 -m pip install ostorlab
WARNING: Running pip install with root privileges is generally not a good idea. Try `python3.9 -m pip install --user` instead.
Collecting ostorlab
# ... lots of pip faffing about...
Successfully built nats-py
Installing collected packages: rpds-py, attrs, referencing, jsonschema-specifications, jsonschema, protobuf, certifi, charset-normalizer, idna, urllib3, requests, semver, typing-extensions, greenlet, sqlalchemy, MarkupSafe, Mako, alembic, nats-py, six, soupsieve, beautifulsoup4, markdownify, py-ubjson, packaging, docker, mdurl, markdown-it-py, pygments, rich, ruamel.yaml.clib, ruamel.yaml, tenacity, proto-plus, googleapis-common-protos, pyasn1, pyasn1-modules, cachetools, rsa, google-auth, grpcio, grpcio-status, google-api-core, google-cloud-audit-log, google-cloud-appengine-logging, grpc-google-iam-v1, google-cloud-core, google-cloud-logging, click, ostorlab
    Running setup.py install for py-ubjson ... done
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

googleapis-common-protos 1.62.0 requires protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
grpcio-status 1.60.0 requires protobuf>=4.21.6, but you'll have protobuf 3.20.1 which is incompatible.
google-api-core 2.15.0 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
google-cloud-audit-log 0.2.5 requires protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
google-cloud-appengine-logging 1.4.0 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
grpc-google-iam-v1 0.13.0 requires protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
google-cloud-logging 3.9.0 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you'll have protobuf 3.20.1 which is incompatible.
Successfully installed Mako-1.3.0 MarkupSafe-2.1.3 alembic-1.13.1 attrs-23.2.0 beautifulsoup4-4.12.2 cachetools-5.3.2 certifi-2023.11.17 charset-normalizer-3.3.2 click-8.1.7 docker-7.0.0 google-api-core-2.15.0 google-auth-2.26.2 google-cloud-appengine-logging-1.4.0 google-cloud-audit-log-0.2.5 google-cloud-core-2.4.1 google-cloud-logging-3.9.0 googleapis-common-protos-1.62.0 greenlet-3.0.3 grpc-google-iam-v1-0.13.0 grpcio-1.60.0 grpcio-status-1.60.0 idna-3.6 jsonschema-4.21.0 jsonschema-specifications-2023.12.1 markdown-it-py-3.0.0 markdownify-0.11.6 mdurl-0.1.2 nats-py-2.6.0 ostorlab-0.18.18 packaging-23.2 proto-plus-1.23.0 protobuf-3.20.1 py-ubjson-0.16.1 pyasn1-0.5.1 pyasn1-modules-0.3.0 pygments-2.17.2 referencing-0.32.1 requests-2.31.0 rich-13.7.0 rpds-py-0.17.1 rsa-4.9 ruamel.yaml-0.18.5 ruamel.yaml.clib-0.2.8 semver-3.0.2 six-1.16.0 soupsieve-2.5 sqlalchemy-1.4.51 tenacity-8.2.3 typing-extensions-4.9.0 urllib3-2.1.0

[root@d0cd328d21b8 /]# ostorlab
Usage: ostorlab [OPTIONS] COMMAND [ARGS]...

  Ostorlab is an open-source project to help automate security testing.

  Ostorlab standardizes interoperability between tools in a consistent,
  scalable, and performant way.

Options:
  --version                      Show the version and exit.
  --api-key TEXT                 API key to login to the platform.
  -X, --proxy TEXT               Proxy to route HTTPS requests through.
  --tlsverify / --no-tlsverify   Control TLS server certificate verification.
  -d, --debug / --no-debug       Enable debug mode
  -v, --verbose / --no-verbose   Enable verbose mode
  --gcp-logging-credential PATH  Path to GCP logging JSON credential file.
  --help                         Show this message and exit.

Commands:
  agent    You can use agent to search, install, bootstrap and run an agent.
  auth     You can use 'auth [subcommand] [options]' to authenticate.
  ci-scan  You can use ci_scan to run scan on the CI.
  scan     Use scan [subcommand] to list, start or stop a scan.
  scanner  Ostorlab scanner enables running custom instances of scanners.
  vulnz    You can use vulnz to list and describe vulnerabilities.
```

</details>