### PR TITLE
Add Detection for CVE-2025-24016

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE ID                                                  | Implemented | Detail                                                  | Published Date |
 |:--------------------------------------------------------|:-----------:|:--------------------------------------------------------|:--------------:|
 | CVE-2025-0108                                           |      ✅      | Custom Nuclei template.                                 |   2025-02-12   |
+| CVE-2025-24016                                          |      ✅      | Custom Nuclei template.                                 |   2025-02-10   |
 | CVE-2025-0674                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-02-04   |
 | CVE-2025-0890                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-02-04   |
 | CVE-2024-55591                                          |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-01-14   |

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -318,6 +318,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-29059.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-53704.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-0108.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-24016.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/CVE-2025-24016.yaml
+++ b/nuclei/CVE-2025-24016.yaml
@@ -1,0 +1,32 @@
+id: CVE-2025-24016
+info:
+  name: "Wazuh Unsafe Deserialization RCE Detection"
+  author: "Hüseyin TINTAŞ"
+  severity: critical
+  description: |
+    This template detects an unsafe deserialization vulnerability in Wazuh servers.
+    The DistributedAPI deserializes JSON data using as_wazuh_object. If an attacker injects
+    a malicious object (via __unhandled_exc__), arbitrary Python code execution can be achieved.
+    Instead of triggering a shutdown (e.g. via exit), this template uses a non-existent class 
+    ("NotARealClass") to generate a NameError. A NameError in the response indicates that the 
+    payload reached the vulnerable deserialization function.
+  tags: wazuh, deserialization, rce, unsafe, cve, cve-2025-24016
+  reference:
+    - https://documentation.wazuh.com/
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/security/user/authenticate/run_as"
+    headers:
+      Content-Type: application/json
+      # If needed, uncomment the following line for authentication (Base64 encoded "wazuh-wui:MyS3cr37P450r.*-", assuming default credentials)
+      Authorization: "Basic d2F6dXcta3dpTUltUzNjcjM3UDA1MHItOg=="
+    body: '{"__unhandled_exc__":{"__class__": "NotARealClass", "__args__": []}}'
+    matchers:
+      - type: status
+        status:
+          - 500
+      - type: word
+        part: body
+        words:
+          - "NameError"


### PR DESCRIPTION
- The template for this vulnerability is inspired from this [PoC](https://github.com/0xjessie21/CVE-2025-24016).
- It works for targets that use default credentials `wazuh-wui:MyS3cr37P450r.*-`.
- No online vulnerable targets were found when testing the template. 