### PR TITLE
fix: False Positive in CVE-2022-43939

### DIFF
--- a/nuclei/CVE-2022-43939.yaml
+++ b/nuclei/CVE-2022-43939.yaml
@@ -42,6 +42,7 @@ http:
     path:
       - "{{BaseURL}}/pentaho/api/repos/:public:/:"
       - "{{BaseURL}}/pentaho/api/repos/%3Apublic%3A/%3A"
+    matchers-condition: and
     matchers:
       - type: status
         status:


### PR DESCRIPTION
The script will match on just status 200 OK instead of ensuring the payload is executed.

It used to match only the 200 status ok instead of ensuring it has pentaho and then run the payload below it.

```yaml
    matchers-condition: and
    matchers:
      - type: status
        status:
          - 200
      - type: word
        words:
          - "Pentaho"
        part: body
```

